### PR TITLE
🔒 Fix hardcoded file paths in Generator.cpp

### DIFF
--- a/src/Functions/Util.h
+++ b/src/Functions/Util.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 
 inline char* resource_path(const char* relative_path) {
     static char full_path[1024];
@@ -15,4 +16,16 @@ inline char* resource_path(const char* relative_path) {
     }
     
     return full_path;
+}
+
+inline std::string output_path(const std::string& filename) {
+    const char* tmpdir = getenv("TMPDIR");
+    if (!tmpdir) {
+        tmpdir = "/tmp";
+    }
+    std::string path = tmpdir;
+    if (!path.empty() && path.back() != '/') {
+        path += "/";
+    }
+    return path + filename;
 }

--- a/src/Generator.cpp
+++ b/src/Generator.cpp
@@ -1,4 +1,5 @@
 #include "GenerateDungeon/Generator.h"
+#include "Functions/Util.h"
 
 std::random_device random_seed;
 std::mt19937 random_engine(random_seed());
@@ -66,7 +67,7 @@ void Generator::outputMap_forDebug() {
     bool charDrawn = false;
 
     std::ofstream writing_file;
-    std::string filename = "debug.map";
+    std::string filename = output_path("debug.map");
     writing_file.open(filename, std::ios::out);
     std::string writing_text = "";
 
@@ -182,7 +183,7 @@ void Generator::outputMap() {
     bool charDrawn = false;
 
     std::ofstream writing_file;
-    std::string filename = "dungeon.map";
+    std::string filename = output_path("dungeon.map");
     writing_file.open(filename, std::ios::out);
     std::string writing_text = "";
 


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability where file paths for debug and dungeon map operations were hardcoded to the current working directory in `src/Generator.cpp`.

⚠️ **Risk:** Hardcoded local file paths can lead to several issues:
- Security risks in shared environments where the current working directory might be sensitive or shared.
- Permission errors if the application is run from a read-only directory.
- Lack of flexibility for users to specify where debug information should be saved.

🛡️ **Solution:** 
- Introduced a new utility function `output_path` in `src/Functions/Util.h`. This function checks for the `TMPDIR` environment variable and falls back to `/tmp` if it's not set. This allows the output directory to be securely configured by the user.
- Updated `Generator::outputMap_forDebug()` and `Generator::outputMap()` in `src/Generator.cpp` to use this new utility for determining the file paths for `debug.map` and `dungeon.map`.
- Normalized line endings in `src/Generator.cpp` to LF to ensure consistent file formatting.

Verification:
- Standalone test program verified the logic of `output_path` handles both cases (TMPDIR set and unset) correctly.
- Code review was performed and rated as correct.
- Manual inspection of the modified files confirms the changes are applied as intended.

---
*PR created automatically by Jules for task [6641661568649342258](https://jules.google.com/task/6641661568649342258) started by @unchunks*