### PR TITLE
🧹 Remove dead debug prints in AStar.cpp

### DIFF
--- a/src/AStar.cpp
+++ b/src/AStar.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "GenerateDungeon/AStar.h"
 
 namespace AStar
@@ -14,8 +13,6 @@ namespace AStar
 	Ivec2 start, goal;
 	std::deque<Ivec2> astar_route;
 }
-
-// int depth = 0;
 
 // マンハッタン距離を求める
 int AStar::GetDistance(int from_x, int from_y)
@@ -39,10 +36,6 @@ int AStar::BackTrace(int x, int y)
 // A*で経路探査する
 int AStar::Search()
 {
-    // depth++;
-
-    // std::cout << "現在の深さ: " << depth << std::endl;
-
 	// 検索中のノード、X・Y座標、実コスト
 	MAPCELL *n = NULL;
 	int CX = 0;
@@ -56,7 +49,7 @@ int AStar::Search()
 			if(astar_map_data[y][x].SearchStatus != SEARCH_OPEN)continue;	// オープンでなければスキップ
 			int cost = GetDistance(x,y);
 			if(cost > cost_min)continue;	// 今よりゴールに遠ければスキップ
-			
+
 			cost_min = cost;
 			n = &astar_map_data[y][x];
 			CX = x;
@@ -107,7 +100,6 @@ int AStar::Search()
 		return -1;
 	}
 
-    // depth--;
 	return Search();
 }
 
@@ -139,27 +131,15 @@ std::deque<Ivec2> AStar::AStar(CELL_TYPE def_data[FLOOR_H][FLOOR_W], Ivec2 _star
 		for(int x = 0; x < FLOOR_W; x++){
             if((def_data[y][x] == FLOOR) || (def_data[y][x] == AISLE) || (def_data[y][x] == STEP))
                 astar_map_data[y][x].status = 0;	// 床
-            else 
+            else
                 astar_map_data[y][x].status = 2;	// 壁
-
-			// if(x == goal.x && y == goal.y)
-			// 	std::cout << "G ";
-			// else if(x == start.x && y == start.y)
-			// 	std::cout << "S ";
-			// else
-			// 	std::cout << ((astar_map_data[y][x].status==0)? " " : "W") << " ";
 		}
-		// std::cout << "\n";
 	}
 	// 開始位置をオープンに
     astar_map_data[start.y][start.x].SearchStatus = SEARCH_OPEN;
     Search();
 
-	// std::cout << "トレース開始\n";
-
 	TraceRoute(goal.x, goal.y);
-
-	// std::cout << "トレース終了\n";
 
 	return astar_route;
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed commented-out debug prints and associated unused variables (`depth`) and headers (`#include <iostream>`) in `src/AStar.cpp`.
- Normalized line endings to LF.

💡 **Why:** How this improves maintainability
- Dead code clutters the codebase and can be confusing for future developers. Removing it improves readability and maintainability.

✅ **Verification:** How you confirmed the change is safe
- Verified file content using `read_file`.
- Successfully compiled the modified file into an object file using `g++`.
- Confirmed that no functional logic was altered.

✨ **Result:** The improvement achieved
- A cleaner, more focused `src/AStar.cpp` without obsolete debug code.

---
*PR created automatically by Jules for task [17446012608605770938](https://jules.google.com/task/17446012608605770938) started by @unchunks*