### PR TITLE
🔒 [security] Fix use of shared static buffer for path formatting

### DIFF
--- a/src/Functions/Util.h
+++ b/src/Functions/Util.h
@@ -1,18 +1,16 @@
 #pragma once
 #include <stdio.h>
 #include <stdlib.h>
+#include <string>
 
-inline char* resource_path(const char* relative_path) {
-    static char full_path[1024];
+inline std::string resource_path(const char* relative_path) {
     const char* appdir = getenv("APPDIR");
     
     if (appdir) {
         // AppImage内で実行されている場合
-        snprintf(full_path, sizeof(full_path), "%s/usr/share/rogue/assets/%s", appdir, relative_path);
+        return std::string(appdir) + "/usr/share/rogue/assets/" + relative_path;
     } else {
         // 通常の実行の場合
-        snprintf(full_path, sizeof(full_path), "assets/%s", relative_path);
+        return std::string("assets/") + relative_path;
     }
-    
-    return full_path;
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -60,12 +60,12 @@ bool Game::Init()
         return false;
     }
 
-    gFontN = TTF_OpenFont(resource_path("JF-Dot-K14.ttf"), 30);
+    gFontN = TTF_OpenFont(resource_path("JF-Dot-K14.ttf").c_str(), 30);
     if (!gFontN) {
         SDL_Log("TTF_OpenFont: %s\n", TTF_GetError());
         return false;
     }
-    gFontB = TTF_OpenFont(resource_path("JF-Dot-K14B.ttf"), 30);
+    gFontB = TTF_OpenFont(resource_path("JF-Dot-K14B.ttf").c_str(), 30);
     if (!gFontB) {
         SDL_Log("TTF_OpenFont: %s\n", TTF_GetError());
         return false;
@@ -113,13 +113,13 @@ bool Game::Init()
         return false;
     }
 
-    gClickEffect = Mix_LoadWAV(resource_path("click.mp3"));
+    gClickEffect = Mix_LoadWAV(resource_path("click.mp3").c_str());
     if(gClickEffect == NULL) {
         SDL_Log("Failed to load sound effect : %s", Mix_GetError());
         return false;
     }
 
-    mMusic = Mix_LoadMUS(resource_path("dungeon.ogg"));//Mix_LoadMUS("assets/BGM.mp3");
+    mMusic = Mix_LoadMUS(resource_path("dungeon.ogg").c_str());//Mix_LoadMUS("assets/BGM.mp3");
     if(mMusic == NULL) {
         SDL_Log("Failed to load BGM : %s", Mix_GetError());
         return false;

--- a/src/Log.cpp
+++ b/src/Log.cpp
@@ -5,7 +5,7 @@ constexpr SDL_Rect Log::logRect;
 Log::Log()
 {
     // なぜか指定したフォントより1大きくなる
-    fontN = TTF_OpenFont(resource_path("JF-Dot-K14.ttf"), FONT_SIZE - 1);
+    fontN = TTF_OpenFont(resource_path("JF-Dot-K14.ttf").c_str(), FONT_SIZE - 1);
     texts.resize(0);
 
 }


### PR DESCRIPTION
🎯 **What:** The `resource_path` function was modified to return a `std::string` instead of a `char*` pointing to a shared static buffer.
⚠️ **Risk:** The use of a static buffer in `resource_path` made it thread-unsafe and susceptible to data corruption if called multiple times in the same expression or from different threads. It also imposed an arbitrary 1024-character limit on paths.
🛡️ **Solution:** By returning `std::string` by value, each call now gets its own copy of the path, ensuring thread safety and removing buffer size limitations. Call sites in `src/Game.cpp` and `src/Log.cpp` were updated to use `.c_str()` when passing the path to SDL2, SDL2_ttf, and SDL2_mixer functions.

---
*PR created automatically by Jules for task [9801950611227793794](https://jules.google.com/task/9801950611227793794) started by @unchunks*