### PR TITLE
🧪 Add edge case tests for Character healing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@ token.txt
 *.zsync
 rogue
 game
+test
+include/
+Character_test.o
+Tile_test.o
 TODO.md
 

--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,15 @@ appimage :
 #	run
 #	bt
 
-test : test.cpp
-	$(CC) test.cpp $(COMPILER_FLAGS) $(COMPILE_OPTIONS) $(LINKER_FLAGS) -o test
+test : test.cpp Character_test.o Tile_test.o
+	$(CC) test.cpp Character_test.o Tile_test.o $(COMPILER_FLAGS) -Iinclude/SDL2 -I. -o test
 	./test
+
+Character_test.o : src/Character.cpp include/SDL2/SDL.h
+	$(CC) -c src/Character.cpp $(COMPILER_FLAGS) -Iinclude/SDL2 -I. -o Character_test.o
+
+Tile_test.o : src/Tile.cpp include/SDL2/SDL.h
+	$(CC) -c src/Tile.cpp $(COMPILER_FLAGS) -Iinclude/SDL2 -I. -o Tile_test.o
 
 commit-% :
 	git add -A

--- a/mock_sdl/SDL.h
+++ b/mock_sdl/SDL.h
@@ -1,0 +1,16 @@
+#ifndef MOCK_SDL_H
+#define MOCK_SDL_H
+#include <stdint.h>
+typedef uint8_t Uint8;
+typedef uint32_t Uint32;
+typedef struct SDL_Rect { int x, y, w, h; } SDL_Rect;
+typedef struct SDL_Color { Uint8 r, g, b, a; } SDL_Color;
+typedef void SDL_Renderer;
+typedef void SDL_Texture;
+typedef void SDL_Window;
+typedef void SDL_Point;
+typedef int SDL_RendererFlip;
+typedef int SDL_BlendMode;
+#define SDL_FLIP_NONE 0
+#define SDL_Log(...)
+#endif

--- a/mock_sdl/SDL2/SDL.h
+++ b/mock_sdl/SDL2/SDL.h
@@ -1,0 +1,16 @@
+#ifndef MOCK_SDL_H
+#define MOCK_SDL_H
+#include <stdint.h>
+typedef uint8_t Uint8;
+typedef uint32_t Uint32;
+typedef struct SDL_Rect { int x, y, w, h; } SDL_Rect;
+typedef struct SDL_Color { Uint8 r, g, b, a; } SDL_Color;
+typedef void SDL_Renderer;
+typedef void SDL_Texture;
+typedef void SDL_Window;
+typedef void SDL_Point;
+typedef int SDL_RendererFlip;
+typedef int SDL_BlendMode;
+#define SDL_FLIP_NONE 0
+#define SDL_Log(...)
+#endif

--- a/mock_sdl/SDL2/SDL_image.h
+++ b/mock_sdl/SDL2/SDL_image.h
@@ -1,0 +1,1 @@
+#include "SDL.h"

--- a/mock_sdl/SDL2/SDL_mixer.h
+++ b/mock_sdl/SDL2/SDL_mixer.h
@@ -1,0 +1,1 @@
+#include "SDL.h"

--- a/mock_sdl/SDL2/SDL_ttf.h
+++ b/mock_sdl/SDL2/SDL_ttf.h
@@ -1,0 +1,1 @@
+#include "SDL.h"

--- a/mock_sdl/SDL_image.h
+++ b/mock_sdl/SDL_image.h
@@ -1,0 +1,1 @@
+#include "SDL.h"

--- a/mock_sdl/SDL_mixer.h
+++ b/mock_sdl/SDL_mixer.h
@@ -1,0 +1,1 @@
+#include "SDL.h"

--- a/mock_sdl/SDL_ttf.h
+++ b/mock_sdl/SDL_ttf.h
@@ -1,0 +1,1 @@
+#include "SDL.h"

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,77 @@
+#include <iostream>
+#include <cassert>
+#include "src/GenerateDungeon/Character.h"
+#include <SDL.h>
+
+// Stubs for global/static variables needed by Character.cpp and Tile.cpp
+SDL_Renderer* gRenderer = nullptr;
+LTexture gTileTexture;
+SDL_Rect gTileClips[TOTAL_TILE_SPRITES];
+
+// We need a dummy for LTexture methods used in Character.cpp and Tile.cpp
+void LTexture::render( int x, int y, SDL_Rect* clip, bool filter, double angle, SDL_Point* center, SDL_RendererFlip flip ) {}
+LTexture::LTexture() : mTexture(nullptr), mWidth(0), mHeight(0) {}
+LTexture::~LTexture() {}
+
+void test_partial_healing() {
+    // x, y, maxHP, STR, VIT, state, dir, type, name
+    Character c(0, 0, 100, 10, 10, ALIVE, DOWN, PLAYER, "TestHero");
+
+    // nowHP starts at 100. reduce it.
+    // receiveDamage(55) -> 55 - (10/2) = 50 damage. nowHP = 50.
+    c.receiveDamage(55);
+    assert(c.getNowHP() == 50);
+
+    c.healed(30);
+    assert(c.getNowHP() == 80);
+    std::cout << "test_partial_healing passed!" << std::endl;
+}
+
+void test_full_healing() {
+    Character c(0, 0, 100, 10, 10, ALIVE, DOWN, PLAYER, "TestHero");
+    c.receiveDamage(55); // nowHP = 50
+
+    c.healed(50);
+    assert(c.getNowHP() == 100);
+    std::cout << "test_full_healing passed!" << std::endl;
+}
+
+void test_overflow_healing() {
+    Character c(0, 0, 100, 10, 10, ALIVE, DOWN, PLAYER, "TestHero");
+    c.receiveDamage(55); // nowHP = 50
+
+    c.healed(100);
+    // Introduce an artificial bug in the test assertion to confirm it can fail
+    // assert(c.getNowHP() == 150); // This should fail
+    assert(c.getNowHP() == 100);
+    std::cout << "test_overflow_healing passed!" << std::endl;
+}
+
+void test_healing_at_max_hp() {
+    Character c(0, 0, 100, 10, 10, ALIVE, DOWN, PLAYER, "TestHero");
+    assert(c.getNowHP() == 100);
+
+    c.healed(10);
+    assert(c.getNowHP() == 100);
+    std::cout << "test_healing_at_max_hp passed!" << std::endl;
+}
+
+void test_healing_with_zero() {
+    Character c(0, 0, 100, 10, 10, ALIVE, DOWN, PLAYER, "TestHero");
+    c.receiveDamage(55); // nowHP = 50
+
+    c.healed(0);
+    assert(c.getNowHP() == 50);
+    std::cout << "test_healing_with_zero passed!" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+    test_partial_healing();
+    test_full_healing();
+    test_overflow_healing();
+    test_healing_at_max_hp();
+    test_healing_with_zero();
+
+    std::cout << "All tests passed using real Character class!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
### 🧪 [Add edge case tests for Character healing]

#### 🎯 **What:**
The testing gap addressed was the lack of unit tests for the `Character::healed` method, which modifies the health state of a character and must correctly cap the value at `maxHP`.

#### 📊 **Coverage:**
The following scenarios are now tested using the actual production code:
- **Partial Healing:** Verified that HP increases correctly when below max.
- **Full Healing:** Verified that HP becomes exactly max when healed by the missing amount.
- **Overflow Healing:** Verified that HP does not exceed `maxHP` when a large heal value is applied.
- **Max HP Healing:** Verified that healing while at full health doesn't change HP.
- **Zero Healing:** Verified that healing by 0 doesn't change HP.

#### ✨ **Result:**
The improvement in test coverage ensures that the core state modification logic of the `Character` class is reliable and prevents regressions in health management. The addition of a mock SDL2 system also makes it easier to add further unit tests in restricted environments.

---
*PR created automatically by Jules for task [9053202694072781011](https://jules.google.com/task/9053202694072781011) started by @unchunks*