### PR TITLE
🔒 [security fix] Sanitize TMPDIR in output_path

### DIFF
--- a/src/Functions/Util.h
+++ b/src/Functions/Util.h
@@ -13,13 +13,11 @@ inline std::string resource_path(const char* relative_path) {
         // 通常の実行の場合
         return std::string("assets/") + relative_path;
     }
-    
-    return full_path;
 }
 
 inline std::string output_path(const std::string& filename) {
     const char* tmpdir = getenv("TMPDIR");
-    if (!tmpdir) {
+    if (!tmpdir || std::string(tmpdir).find("..") != std::string::npos || std::string(tmpdir).find("/") != 0) {
         tmpdir = "/tmp";
     }
     std::string path = tmpdir;

--- a/tests/test_util.cpp
+++ b/tests/test_util.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <string>
+#include <cassert>
+#include <stdlib.h>
+#include "Functions/Util.h"
+
+void test_output_path_vulnerability() {
+    // Test default behavior
+    unsetenv("TMPDIR");
+    assert(output_path("test.txt") == "/tmp/test.txt");
+
+    // Test path traversal vulnerability - should fallback to /tmp
+    setenv("TMPDIR", "/tmp/../etc", 1);
+    std::string path = output_path("passwd");
+    std::cout << "Path with malicious TMPDIR (traversal): " << path << std::endl;
+    assert(path == "/tmp/passwd");
+
+    // Test relative path - should fallback to /tmp
+    setenv("TMPDIR", "relative/path", 1);
+    path = output_path("test.txt");
+    std::cout << "Path with malicious TMPDIR (relative): " << path << std::endl;
+    assert(path == "/tmp/test.txt");
+
+    // Test valid absolute path
+    setenv("TMPDIR", "/var/tmp", 1);
+    path = output_path("test.txt");
+    std::cout << "Path with valid TMPDIR: " << path << std::endl;
+    assert(path == "/var/tmp/test.txt");
+
+    // Test valid absolute path without trailing slash
+    setenv("TMPDIR", "/var/tmp/", 1);
+    path = output_path("test.txt");
+    std::cout << "Path with valid TMPDIR (trailing slash): " << path << std::endl;
+    assert(path == "/var/tmp/test.txt");
+}
+
+void test_resource_path() {
+    // Test default behavior
+    unsetenv("APPDIR");
+    assert(resource_path("hero.png") == "assets/hero.png");
+
+    // Test AppImage behavior
+    setenv("APPDIR", "/tmp/appimage.12345", 1);
+    assert(resource_path("hero.png") == "/tmp/appimage.12345/usr/share/rogue/assets/hero.png");
+}
+
+int main() {
+    test_output_path_vulnerability();
+    test_resource_path();
+    std::cout << "Util tests completed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an unsafe use of the `TMPDIR` environment variable for file path construction in `output_path`.

⚠️ **Risk:** Without validation, an attacker could set `TMPDIR` to a path containing `..` to perform a path traversal attack, potentially causing the application to write files to unintended locations.

🛡️ **Solution:** The fix adds checks to ensure `TMPDIR` is an absolute path (starts with `/`) and does not contain any traversal sequences (`..`). If any of these checks fail, or if `TMPDIR` is not set, the function defaults to using `/tmp`. Additionally, a bug in `resource_path` that prevented compilation was fixed, and a comprehensive unit test for `Util.h` was added.

---
*PR created automatically by Jules for task [17796484978378432196](https://jules.google.com/task/17796484978378432196) started by @unchunks*