### PR TITLE
🧪 Add unit tests for Player::reset()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ Character_test.o
 Tile_test.o
 TODO.md
 tests/test_run
+tests/test_player_run
 

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,15 @@ appimage :
 #	run
 #	bt
 
-test : tests/test_AinB.cpp src/Functions/RectUtils.h
+test : tests/test_AinB.cpp tests/test_Player.cpp src/Functions/RectUtils.h
 	$(CC) $(COMPILER_FLAGS) -I./tests/include -I./src tests/test_AinB.cpp -o tests/test_run
 	./tests/test_run
+	$(CC) $(COMPILER_FLAGS) -I./tests/include -I./src tests/test_Player.cpp src/Player.cpp src/Character.cpp src/Tile.cpp src/LTexture.cpp -o tests/test_player_run
+	./tests/test_player_run
+
+test_player : tests/test_Player.cpp src/Player.cpp src/Character.cpp src/Tile.cpp src/LTexture.cpp
+	$(CC) $(COMPILER_FLAGS) -I./tests/include -I./src tests/test_Player.cpp src/Player.cpp src/Character.cpp src/Tile.cpp src/LTexture.cpp -o tests/test_player_run
+	./tests/test_player_run
 
 commit-% :
 	git add -A

--- a/tests/include/SDL2/SDL.h
+++ b/tests/include/SDL2/SDL.h
@@ -1,6 +1,8 @@
 #ifndef SDL_H
 #define SDL_H
 
+#include <stdarg.h>
+
 typedef struct SDL_Rect {
     int x, y;
     int w, h;
@@ -22,6 +24,31 @@ typedef enum { SDL_BLENDMODE_NONE = 0 } SDL_BlendMode;
 typedef struct { unsigned char r, g, b, a; } SDL_Color;
 typedef unsigned char Uint8;
 
+typedef struct SDL_Surface {
+    int w, h;
+    void* pixels;
+    struct { int format; }* format;
+} SDL_Surface;
+
+#define SDL_TRUE 1
+#define SDL_FALSE 0
+
 #define SDL_GetError() "Mock error"
+#define IMG_GetError() "Mock IMG error"
+
+void SDL_SetRenderDrawColor(SDL_Renderer* renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+void SDL_RenderFillRect(SDL_Renderer* renderer, const SDL_Rect* rect);
+void SDL_Log(const char* fmt, ...);
+int SDL_SetColorKey(SDL_Surface* surface, int flag, int key);
+int SDL_MapRGB(const void* format, Uint8 r, Uint8 g, Uint8 b);
+void SDL_DestroyTexture(SDL_Texture* texture);
+int SDL_SetTextureColorMod(SDL_Texture* texture, Uint8 r, Uint8 g, Uint8 b);
+int SDL_SetTextureBlendMode(SDL_Texture* texture, SDL_BlendMode blendMode);
+int SDL_SetTextureAlphaMod(SDL_Texture* texture, Uint8 alpha);
+int SDL_RenderCopyEx(SDL_Renderer* renderer, SDL_Texture* texture, const SDL_Rect* srcrect, const SDL_Rect* dstrect, const double angle, const SDL_Point* center, const SDL_RendererFlip flip);
+
+inline SDL_Surface* IMG_Load(const char* file) { return (SDL_Surface*)0; }
+inline void SDL_FreeSurface(SDL_Surface* surface) {}
+inline SDL_Texture* SDL_CreateTextureFromSurface(SDL_Renderer* renderer, SDL_Surface* surface) { return (SDL_Texture*)0; }
 
 #endif

--- a/tests/include/SDL2/SDL_image.h
+++ b/tests/include/SDL2/SDL_image.h
@@ -3,13 +3,4 @@
 
 #include "SDL.h"
 
-typedef struct SDL_Surface {
-    int w, h;
-    void* pixels;
-} SDL_Surface;
-
-inline SDL_Surface* IMG_Load(const char* file) { return (SDL_Surface*)0; }
-inline void SDL_FreeSurface(SDL_Surface* surface) {}
-inline SDL_Texture* SDL_CreateTextureFromSurface(SDL_Renderer* renderer, SDL_Surface* surface) { return (SDL_Texture*)0; }
-
 #endif

--- a/tests/test_Player.cpp
+++ b/tests/test_Player.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <cassert>
+#include <vector>
+#include <string>
+#include <stdarg.h>
+
+#include "SDL2/SDL.h"
+#include "GenerateDungeon/Player.h"
+#include "GenerateDungeon/Character.h"
+
+// Stubs for global/static variables needed by Character.cpp and Tile.cpp
+SDL_Renderer* gRenderer = nullptr;
+LTexture gTileTexture;
+SDL_Rect gTileClips[TOTAL_TILE_SPRITES];
+
+// Stubs for missing SDL functions
+void SDL_SetRenderDrawColor(SDL_Renderer* renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a) {}
+void SDL_RenderFillRect(SDL_Renderer* renderer, const SDL_Rect* rect) {}
+void SDL_Log(const char* fmt, ...) {}
+int SDL_SetColorKey(SDL_Surface* surface, int flag, int key) { return 0; }
+int SDL_MapRGB(const void* format, Uint8 r, Uint8 g, Uint8 b) { return 0; }
+void SDL_DestroyTexture(SDL_Texture* texture) {}
+int SDL_SetTextureColorMod(SDL_Texture* texture, Uint8 r, Uint8 g, Uint8 b) { return 0; }
+int SDL_SetTextureBlendMode(SDL_Texture* texture, SDL_BlendMode blendMode) { return 0; }
+int SDL_SetTextureAlphaMod(SDL_Texture* texture, Uint8 alpha) { return 0; }
+int SDL_RenderCopyEx(SDL_Renderer* renderer, SDL_Texture* texture, const SDL_Rect* srcrect, const SDL_Rect* dstrect, const double angle, const SDL_Point* center, const SDL_RendererFlip flip) { return 0; }
+
+void test_player_reset() {
+    std::cout << "Running test_player_reset..." << std::endl;
+
+    // Initial setup: maxHP=100, STR=20, VIT=20
+    Player p(10, 20, 100, 20, 20);
+
+    // 1. Modify states to non-default values
+    p.receiveDamage(50); // nowHP becomes 60 (100 - (50 - 20/2))
+    assert(p.getNowHP() == 60);
+
+    p.levelUp(100); // level becomes 2, exp becomes 0, maxHP += 10 (110), nowHP += 10 (70)
+    assert(p.level == 2);
+    assert(p.getMaxHP() == 110);
+    assert(p.getNowHP() == 70);
+
+    p.setDir(LEFT);
+    p.setState(DEAD);
+
+    // 2. Call reset
+    p.reset();
+
+    // 3. Verify reset states
+    // nowHP should be reset to current maxHP
+    assert(p.getNowHP() == p.getMaxHP());
+    assert(p.getNowHP() == 110); // Note: current implementation doesn't reset maxHP to initial
+
+    // mState should be ALIVE
+    assert(p.getState() == ALIVE);
+
+    // mDir should be DOWN
+    assert(p.getDir() == DOWN);
+
+    // level should be 1
+    assert(p.level == 1);
+
+    // exp should be 0
+    assert(p.exp == 0);
+
+    std::cout << "test_player_reset passed!" << std::endl;
+}
+
+int main() {
+    test_player_reset();
+    std::cout << "All Player tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
This PR adds unit tests for the `Player::reset()` function, which was previously untested.

### 📊 Coverage: What scenarios are now tested
The new test case `test_player_reset` in `tests/test_Player.cpp` covers:
- Verification that `nowHP` is reset to the current `maxHP` (even after leveling up).
- Verification that `level` is reset to 1.
- Verification that `exp` is reset to 0.
- Verification that `mState` is reset to `ALIVE`.
- Verification that `mDir` is reset to `DOWN`.

The test uses a mocking strategy for SDL2 to allow it to run in environments without the full library installed.

### ✨ Result: The improvement in test coverage
Reliability of the player reset logic is now programmatically verified, ensuring that any future regressions in the reset behavior will be caught by the test suite. Both the new `test_player` target and the existing `test` target in the `Makefile` now include these checks.

---
*PR created automatically by Jules for task [17462784601014245394](https://jules.google.com/task/17462784601014245394) started by @unchunks*