### PR TITLE
🧹 Implement logic for reaching the lowest floor

### DIFF
--- a/src/4_Dungeon.cpp
+++ b/src/4_Dungeon.cpp
@@ -93,7 +93,7 @@ void Dungeon::Input(SDL_Event event)
                 e.isMoved = true;
             }
             // SDL_Log("敵のターン===============================================================================");
-        	break;
+		break;
         case SDLK_q:
             player.isMoved = false;
             in_dungeon = false;
@@ -243,7 +243,7 @@ void Dungeon::Update()
 
             if(!e.isMoved)
                 continue;
-            
+
             switch (e.getState())
             {
                 case SEARCH:
@@ -291,7 +291,7 @@ GOTO_FOUND:
                     {
                         updateEnemyRoute(e, PLAYER_POS);
                     }
-                    
+
                     e.walk(tileSet, player, enemies);
                     break;
 
@@ -333,9 +333,9 @@ GOTO_FOUND:
                 {
                     log.addText(player.getName() + "はレベルアップした！");
                     log.addText(
-                        "Lv." + std::to_string(player.level) + 
-                        "　HP:" + std::to_string(player.getMaxHP()) + 
-                        "　STR:" + std::to_string(player.getSTR()) + 
+                        "Lv." + std::to_string(player.level) +
+                        "　HP:" + std::to_string(player.getMaxHP()) +
+                        "　STR:" + std::to_string(player.getSTR()) +
                         "　VIT:" + std::to_string(player.getVIT())
                     );
                 }
@@ -386,7 +386,7 @@ void Dungeon::Output()
 
     for (auto &e : enemies)
         e.render(camera);
-    
+
     log.render(gRenderer);
 }
 
@@ -454,8 +454,7 @@ void Dungeon::InitDungeon()
     in_dungeon = true;
     go_next_floor = false;
 
-//TODO: 最下層についたときの処理を追加
-    if (floor_num >= LAST_FLOOR)
+    if (floor_num > LAST_FLOOR)
     {
         quit();
         gNowScene = SCENE::CONGRATULATIONS;
@@ -463,6 +462,11 @@ void Dungeon::InitDungeon()
     }
 
     log.reset();
+
+    if (floor_num == LAST_FLOOR)
+    {
+        log.addText("ついに最下層に到達した！");
+    }
 
     // 選択した方法でダンジョンを生成
     switch (gNowScene)

--- a/src/Functions/Util.h
+++ b/src/Functions/Util.h
@@ -5,16 +5,17 @@
 
 inline std::string resource_path(const char* relative_path) {
     const char* appdir = getenv("APPDIR");
-    
+    std::string path;
+
     if (appdir) {
         // AppImage内で実行されている場合
-        return std::string(appdir) + "/usr/share/rogue/assets/" + relative_path;
+        path = std::string(appdir) + "/usr/share/rogue/assets/";
     } else {
         // 通常の実行の場合
-        return std::string("assets/") + relative_path;
+        path = "assets/";
     }
-    
-    return full_path;
+
+    return path + relative_path;
 }
 
 inline std::string output_path(const std::string& filename) {


### PR DESCRIPTION
🎯 **What:** Implemented the logic for reaching and playing through the lowest floor (floor 10) of the dungeon. Also fixed a critical compilation bug in the `resource_path` utility.

💡 **Why:** Previously, the game would immediately end when reaching the 10th floor without letting the player play it. The `resource_path` function had an undeclared variable `full_path` and lacked a proper return path in some cases, leading to compilation failures and undefined behavior.

✅ **Verification:** Verified by syntax checking (compiling to object files) using mock SDL2 headers. I confirmed that `src/4_Dungeon.cpp` and `src/Functions/Util.h` both compile successfully.

✨ **Result:** Improved game progression logic and fixed a core utility bug, enhancing both the player experience and the codebase's maintainability.

---
*PR created automatically by Jules for task [1106511496747954061](https://jules.google.com/task/1106511496747954061) started by @unchunks*